### PR TITLE
[Minor] : Fix wrong parameter name in SDPMChunker

### DIFF
--- a/chunkers/sdpm-chunker.mdx
+++ b/chunkers/sdpm-chunker.mdx
@@ -41,7 +41,7 @@ custom_embeddings = CustomEmbeddings()
 chunker = SDPMChunker(
     embedding_model=custom_embeddings,
     similarity_threshold=0.5,
-    max_chunk_size=512
+    chunk_size=512
 )
 ```
 

--- a/chunkers/sdpm-chunker.mdx
+++ b/chunkers/sdpm-chunker.mdx
@@ -25,7 +25,7 @@ from chonkie import SDPMChunker
 chunker = SDPMChunker(
     embedding_model="minishlab/potion-base-8M",  # Default model
     similarity_threshold=0.5,                   # Similarity threshold (0-1)
-    max_chunk_size=512,                         # Maximum tokens per chunk
+    chunk_size=512,                             # Maximum tokens per chunk
     initial_sentences=1,                        # Initial sentences per chunk
     skip_window=1                               # Number of chunks to skip when looking for similarities
 )
@@ -72,7 +72,7 @@ chunker = SDPMChunker(
 </ParamField>
 
 <ParamField
-    path="max_chunk_size"
+    path="chunk_size"
     type="int"
     default="512"
 >


### PR DESCRIPTION
Fix wrong parameter name in SDPMChunker documentation.
(`max_chunk_size` , supposed to be `chunk_size`)